### PR TITLE
feat: introduced a new codemod to remove unused imports once finish

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npx @lingui/codemods <transform> <path> --jscodeshift="--printOptions='{\"quote\
 A CLI is built-in to help you migrate your codebase, will ask you some questions:
 
 ```sh
-➜  project git:(master) @lingui/codemods
+➜  project git:(master) npx @lingui/codemods
 ? On which files or directory should the codemods be applied? for ex: ./src
 ? Which dialect of JavaScript do you use? for ex: JavaScript | Typescript | JavaScript with Flow
 ? Which transform would you like to apply? for ex: `v2-to-v3`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ This repository contains a collection of codemod scripts for use with [JSCodeshi
 
 - `transform` - name of transform, see available transforms below.
 - `path` - files or directory to transform
-- use the `--dry` option for a dry-run and use `--print` to print the output for comparison
+- use the `--dry` option for a dry-run
+- use `--print` to print the output for
+ comparison
+- use `--remove-unused-imports` to remove unused imports once finished the codemod
+
 
 This will start an interactive wizard, and then run the specified transform.
 
@@ -53,7 +57,7 @@ npx @lingui/codemods <transform> <path> --jscodeshift="--printOptions='{\"quote\
 A CLI is built-in to help you migrate your codebase, will ask you some questions:
 
 ```sh
-➜  project git:(master) lingui-codemod
+➜  project git:(master) @lingui/codemods
 ? On which files or directory should the codemods be applied? for ex: ./src
 ? Which dialect of JavaScript do you use? for ex: JavaScript | Typescript | JavaScript with Flow
 ? Which transform would you like to apply? for ex: `v2-to-v3`

--- a/bin/__tests__/lingui-codemod.test.ts
+++ b/bin/__tests__/lingui-codemod.test.ts
@@ -90,7 +90,7 @@ describe('runTransform', () => {
   });
 
   it('runs jscodeshift for the given transformer', () => {
-    execaReturnValue = { error: null };
+    execaReturnValue = { failed: false };
     console.log = jest.fn();
     runTransform({
       files: 'src',
@@ -108,7 +108,7 @@ describe('runTransform', () => {
   });
 
   it('supports jscodeshift flags', () => {
-    execaReturnValue = { error: null };
+    execaReturnValue = { failed: false };
     console.log = jest.fn();
     runTransform({
       files: 'folder',
@@ -126,7 +126,7 @@ describe('runTransform', () => {
   });
 
   it('supports typescript parser', () => {
-    execaReturnValue = { error: null };
+    execaReturnValue = { failed: false };
     console.log = jest.fn();
     runTransform({
       files: 'folder',
@@ -144,7 +144,7 @@ describe('runTransform', () => {
   });
 
   it('supports jscodeshift custom arguments', () => {
-    execaReturnValue = { error: null };
+    execaReturnValue = { failed: false };
     console.log = jest.fn();
     runTransform({
       files: 'folder',
@@ -164,9 +164,38 @@ describe('runTransform', () => {
     );
   });
 
+  it('supports remove-unused-imports flag that runs a codemod to clean all unused imports', () => {
+    execaReturnValue = { failed: false };
+    console.log = jest.fn();
+    runTransform({
+      files: 'folder',
+      flags: {
+        removeUnusedImports: true,
+      },
+      parser: 'babel',
+      transformer: 'v2-to-v3'
+    });
+    expect(console.log).toBeCalledTimes(2)
+    // @ts-ignore
+    expect(console.log.mock.calls).toEqual([
+      [
+        `Executing command: jscodeshift --verbose=2 --ignore-pattern=**/node_modules/** --parser babel --extensions=jsx,js --transform ${path.join(
+          transformerDirectory,
+          'v2-to-v3.js'
+        )} folder`
+      ],
+      [
+        `Executing command: jscodeshift --verbose=2 --ignore-pattern=**/node_modules/** --parser babel --extensions=jsx,js --transform ${path.join(
+          transformerDirectory,
+          'remove-unused-imports.js'
+        )} folder`
+      ]
+    ]);
+  });
+
   it('rethrows jscodeshift errors', () => {
     const transformerError = new Error('bum');
-    execaReturnValue = { error: transformerError };
+    execaReturnValue = { failed: true, stderr: transformerError };
     console.log = jest.fn();
     expect(() => {
       runTransform({

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@ module.exports = {
   verbose: true,
   roots: ["<rootDir>/transforms", "<rootDir>/bin"],
   transform: {
-    "^.+\\.tsx?$": "ts-jest"
+    "^.+\\.ts?$": "ts-jest"
   }
 };

--- a/transforms/__testfixtures__/remove-unused-imports/remove-unused-imports.input.js
+++ b/transforms/__testfixtures__/remove-unused-imports/remove-unused-imports.input.js
@@ -1,0 +1,14 @@
+import { React, core } from "react";
+import { date, number } from "@lingui/core";
+import { t } from "@lingui/macro";
+
+export default () => {
+  const [gi, setgi] = React.useState(false)
+  return (
+    <>
+      {t`Some example`}
+      {date(new Date())}
+      <div>hola</div>
+    </>
+  )
+}

--- a/transforms/__testfixtures__/remove-unused-imports/remove-unused-imports.output.js
+++ b/transforms/__testfixtures__/remove-unused-imports/remove-unused-imports.output.js
@@ -1,0 +1,14 @@
+import { React } from "react";
+import { date } from "@lingui/core";
+import { t } from "@lingui/macro";
+
+export default () => {
+  const [gi, setgi] = React.useState(false)
+  return (
+    <>
+      {t`Some example`}
+      {date(new Date())}
+      <div>hola</div>
+    </>
+  )
+}

--- a/transforms/__tests__/remove-unused-imports.test.ts
+++ b/transforms/__tests__/remove-unused-imports.test.ts
@@ -1,0 +1,10 @@
+import { defineTest } from "jscodeshift/dist/testUtils";
+
+describe("We remove all the unused imports", () => {
+  defineTest(
+    __dirname,
+    "remove-unused-imports",
+    null,
+    "remove-unused-imports/remove-unused-imports",
+  );
+});

--- a/transforms/remove-unused-imports.ts
+++ b/transforms/remove-unused-imports.ts
@@ -1,0 +1,60 @@
+import { Transform } from "jscodeshift";
+
+const transform: Transform = (fileInfo, api, options) => {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+
+  const filterAndTransformRequires = path => {
+    const specifiers = path.value.specifiers;
+    const parentScope = j(path).closestScope();
+    return (
+      specifiers.filter(importPath => {
+        const varName = importPath.local.name;
+        const requireName = importPath.imported
+          ? importPath.imported.name
+          : importPath.local.name;
+        const scopeNode = path.scope.node;
+
+        // We need this to make sure the JSX transform can use `React`
+        if (requireName === "React") {
+          return false;
+        }
+
+        // console.debug("parsing require named ", requireName);
+        // Remove required vars that aren't used.
+        const identifierUsages = parentScope
+          .find(j.Identifier, { name: varName })
+          // Ignore require vars
+          .filter(identifierPath => identifierPath.parentPath.value !== importPath);
+        const decoratorUsages = parentScope.find(j.ClassDeclaration).filter((it: any) => {
+          return (
+            (it.value.decorators || []).filter(
+              decorator => decorator.expression.name === varName
+            ).length > 0
+          );
+        });
+
+        if (!identifierUsages.size() && !decoratorUsages.size()) {
+          path.value.specifiers = path.value.specifiers.filter(
+            it => (it === importPath) === false
+          );
+          if (path.value.specifiers.length === 0) {
+            j(path).remove();
+          }
+          return true;
+        }
+      }).length > 0
+    );
+  };
+
+  const didTransform =
+    root
+      .find(j.ImportDeclaration)
+      .filter(filterAndTransformRequires)
+      .size() > 0;
+
+  return didTransform ? root.toSource(options.printOptions) : null;
+};
+
+
+export default transform;

--- a/transforms/v2-to-v3.ts
+++ b/transforms/v2-to-v3.ts
@@ -1,6 +1,6 @@
 import { Transform, JSCodeshift, Collection } from "jscodeshift";
 
-const transform: Transform = (fileInfo, api) => {
+const transform: Transform = (fileInfo, api, options) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
 
@@ -11,7 +11,7 @@ const transform: Transform = (fileInfo, api) => {
   changeFromMacroToCore(root, j)
   pluralPropsChanges(root, j)
 
-  return root.toSource();
+  return root.toSource(options.printOptions);
 };
 
 export default transform;


### PR DESCRIPTION
Introduced a new codemod to remove all the unused imports if the user wants to.

just passing `@lingui/codemods v2-to-v3 ./src --remove-unused-imports` will automatically clean all the unused imports once finish the v2-to-v3 transform