### PR TITLE
chore: Add missing newlines to release message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build_and_testing:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/release.config.js
+++ b/release.config.js
@@ -15,7 +15,7 @@ module.exports = {
     ],
     {
       assets: ["package.json", "CHANGELOG.md"],
-      message: "chore(release): ${nextRelease.version} ${nextRelease.notes}",
+      message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
       path: "@semantic-release/git",
     },
     "@semantic-release/github"


### PR DESCRIPTION
It seems there're missing newlines in release commit message.

See example at https://github.com/semantic-release/git#usage