### PR TITLE
fix: include comments in t macro transform

### DIFF
--- a/transforms/__testfixtures__/v2-to-v3/t.input.js
+++ b/transforms/__testfixtures__/v2-to-v3/t.input.js
@@ -6,3 +6,6 @@ t('my.id')`Some input`
 const value = 1
 t('my.id')`Some value (${value})`
 t('my.id')`Some complex value (${value.toFixed(2)})`
+const withComment = /**i18n: a description of the message*/t`Some message`
+test`no transform`
+test('id')`no transform`

--- a/transforms/__testfixtures__/v2-to-v3/t.output.js
+++ b/transforms/__testfixtures__/v2-to-v3/t.output.js
@@ -15,3 +15,9 @@ t({
   id: "my.id",
   message: `Some complex value (${value.toFixed(2)})`
 })
+const withComment = t({
+  message: `Some message`,
+  comment: "a description of the message"
+})
+test`no transform`
+test('id')`no transform`


### PR DESCRIPTION
I ran this codemod against my codebase and noticed it stripped out all of my message descriptions, so I beat my head against jscodeshift and its complete lack of documentation for a bit and here we are, a working transform that includes comments. I updated the tests to ensure it works and that only the `t` macro is being transformed.

```js
// v2
t`abc`
t('key')`abc`
/**i18n: some description*/t`abc`
/**i18n: some description*/t('key')`abc`

//v3
t`abc`
t({
  id: 'key',
  message: 'abc'
})
t({
  message: `abc`,
  comment: 'some description'
})
t({
  id: 'key',
  message: `abc`,
  comment: 'some description'
})
```